### PR TITLE
Added a HDInsight specific temporary workaround to include missing datanucleus jars when running Hive on Spark via notebook.

### DIFF
--- a/livy-repl/src/main/resources/logback.xml
+++ b/livy-repl/src/main/resources/logback.xml
@@ -5,8 +5,21 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
+    <appender name="Etw" class="com.microsoft.log4jappender.logback.LogbackEtwAppender">
+        <source>HadoopServiceLog</source>
+        <component>sparklivy</component>
+        <OSType>Linux</OSType>
+    </appender>
+    <appender name="EtwFilter" class="com.microsoft.log4jappender.logback.LogbackFilterLogAppender">
+        <source>CentralFilteredHadoopServiceLogs</source>
+        <component>sparklivy</component>
+        <whitelistFileName>NA</whitelistFileName>
+        <OSType>Linux</OSType>
+    </appender>
 
     <root level="info">
         <appender-ref ref="STDOUT" />
+        <appender-ref ref="Etw" />
+        <appender-ref ref="EtwFilter" />
     </root>
 </configuration>

--- a/livy-server/src/main/resources/logback.xml
+++ b/livy-server/src/main/resources/logback.xml
@@ -5,8 +5,21 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
+    <appender name="Etw" class="com.microsoft.log4jappender.logback.LogbackEtwAppender">
+        <source>HadoopServiceLog</source>
+        <component>sparklivy</component>
+        <OSType>Linux</OSType>
+    </appender>
+    <appender name="EtwFilter" class="com.microsoft.log4jappender.logback.LogbackFilterLogAppender">
+        <source>CentralFilteredHadoopServiceLogs</source>
+        <component>sparklivy</component>
+        <whitelistFileName>NA</whitelistFileName>
+        <OSType>Linux</OSType>
+    </appender>
 
     <root level="info">
         <appender-ref ref="STDOUT" />
+        <appender-ref ref="Etw" />
+        <appender-ref ref="EtwFilter" />
     </root>
 </configuration>

--- a/livy-spark/src/main/scala/com/cloudera/hue/livy/spark/SparkProcessBuilder.scala
+++ b/livy-spark/src/main/scala/com/cloudera/hue/livy/spark/SparkProcessBuilder.scala
@@ -282,7 +282,7 @@ class SparkProcessBuilder(livyConf: LivyConf, userConfigurableOptions: Set[Strin
   private def fromPath(path: Path) = path match {
     case AbsolutePath(p) => p
     case RelativePath(p) =>
-      if (p.startsWith("hdfs://")) {
+      if (p.startsWith("hdfs://") || p.startsWith("wasb://")) {
         p
       } else {
         fsRoot + "/" + p

--- a/livy-spark/src/main/scala/com/cloudera/hue/livy/spark/SparkProcessBuilder.scala
+++ b/livy-spark/src/main/scala/com/cloudera/hue/livy/spark/SparkProcessBuilder.scala
@@ -220,6 +220,10 @@ class SparkProcessBuilder(livyConf: LivyConf, userConfigurableOptions: Set[Strin
   }
 
   def start(file: Path, args: Traversable[String]): SparkProcess = {
+    val sparkHome = livyConf.sparkHome().getOrElse {
+      System.err.println("Livy requires the SPARK_HOME environment variable")
+      sys.exit(1)
+    }
     var arguments = ArrayBuffer(fromPath(_executable))
 
     def addOpt(option: String, value: Option[String]): Unit = {
@@ -239,7 +243,10 @@ class SparkProcessBuilder(livyConf: LivyConf, userConfigurableOptions: Set[Strin
     addOpt("--master", _master)
     addOpt("--deploy-mode", _deployMode)
     addOpt("--name", _name)
-    addList("--jars", _jars.map(fromPath))
+    addList("--jars", _jars.map(fromPath).+=(
+      s"$sparkHome/lib/datanucleus-core-3.2.10.jar",
+      s"$sparkHome/lib/datanucleus-api-jdo-3.2.6.jar",
+      s"$sparkHome/lib/datanucleus-rdbms-3.2.9.jar"))
     addList("--py-files", _pyFiles.map(fromPath))
     addList("--files", _files.map(fromPath))
     addOpt("--class", _className)

--- a/livy-yarn/src/main/resources/logback.xml
+++ b/livy-yarn/src/main/resources/logback.xml
@@ -5,8 +5,21 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
+    <appender name="Etw" class="com.microsoft.log4jappender.logback.LogbackEtwAppender">
+        <source>HadoopServiceLog</source>
+        <component>sparklivy</component>
+        <OSType>Linux</OSType>
+    </appender>
+    <appender name="EtwFilter" class="com.microsoft.log4jappender.logback.LogbackFilterLogAppender">
+        <source>CentralFilteredHadoopServiceLogs</source>
+        <component>sparklivy</component>
+        <whitelistFileName>NA</whitelistFileName>
+        <OSType>Linux</OSType>
+    </appender>
 
     <root level="info">
         <appender-ref ref="STDOUT" />
+        <appender-ref ref="Etw" />
+        <appender-ref ref="EtwFilter" />
     </root>
 </configuration>


### PR DESCRIPTION
We should revert this once we fixed our application to include datanucleus jars in the session request.
