### PR TITLE
LIVY-221. Default Livy name is overwriting spark.app.name.

### DIFF
--- a/server/src/main/scala/com/cloudera/livy/utils/SparkProcessBuilder.scala
+++ b/server/src/main/scala/com/cloudera/livy/utils/SparkProcessBuilder.scala
@@ -31,7 +31,7 @@ class SparkProcessBuilder(livyConf: LivyConf) extends Logging {
   private[this] var _master: Option[String] = None
   private[this] var _deployMode: Option[String] = None
   private[this] var _className: Option[String] = None
-  private[this] var _name: Option[String] = Some("Livy")
+  private[this] var _name: Option[String] = None
   private[this] var _jars: ArrayBuffer[String] = ArrayBuffer()
   private[this] var _pyFiles: ArrayBuffer[String] = ArrayBuffer()
   private[this] var _files: ArrayBuffer[String] = ArrayBuffer()


### PR DESCRIPTION
Removed default value for name parameter.
